### PR TITLE
Actually open AI

### DIFF
--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -41,10 +41,6 @@ fn register_language_model_providers(
     RefreshLlmTokenListener::register(client.clone(), cx);
 
     registry.register_provider(
-        AnthropicLanguageModelProvider::new(client.http_client(), cx),
-        cx,
-    );
-    registry.register_provider(
         OpenAiLanguageModelProvider::new(client.http_client(), cx),
         cx,
     );
@@ -52,19 +48,6 @@ fn register_language_model_providers(
         OllamaLanguageModelProvider::new(client.http_client(), cx),
         cx,
     );
-    registry.register_provider(
-        LmStudioLanguageModelProvider::new(client.http_client(), cx),
-        cx,
-    );
-    registry.register_provider(
-        DeepSeekLanguageModelProvider::new(client.http_client(), cx),
-        cx,
-    );
-    registry.register_provider(
-        GoogleLanguageModelProvider::new(client.http_client(), cx),
-        cx,
-    );
-    registry.register_provider(CopilotChatLanguageModelProvider::new(cx), cx);
 
     cx.observe_flag::<feature_flags::LanguageModels, _>(move |enabled, cx| {
         let user_store = user_store.clone();

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -155,13 +155,6 @@ impl LanguageModelProvider for OpenAiLanguageModelProvider {
     fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
         let mut models = BTreeMap::default();
 
-        // Add base models from open_ai::Model::iter()
-        for model in open_ai::Model::iter() {
-            if !matches!(model, open_ai::Model::Custom { .. }) {
-                models.insert(model.id().to_string(), model);
-            }
-        }
-
         // Override with available models from settings
         for model in &AllLanguageModelSettings::get_global(cx)
             .openai

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -475,12 +475,11 @@ impl ConfigurationView {
 
 impl Render for ConfigurationView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        const OPENAI_CONSOLE_URL: &str = "https://platform.openai.com/api-keys";
         const INSTRUCTIONS: [&str; 4] = [
-            "To use Zed's assistant with OpenAI, you need to add an API key. Follow these steps:",
-            " - Create one by visiting:",
-            " - Ensure your OpenAI account has credits",
+            "To use Zed's assistant with an OpenAI-compatible provider, follow these steps:",
+            " - Configure the provider in the config file",
             " - Paste your API key below and hit enter to start using the assistant",
+            " - If your provider has no authentication, just insert a dummy key",
         ];
 
         let env_var_set = self.state.read(cx).api_key_from_env;
@@ -491,18 +490,8 @@ impl Render for ConfigurationView {
             v_flex()
                 .size_full()
                 .on_action(cx.listener(Self::save_api_key))
-                .child(Label::new(INSTRUCTIONS[0]))
-                .child(h_flex().child(Label::new(INSTRUCTIONS[1])).child(
-                    Button::new("openai_console", OPENAI_CONSOLE_URL)
-                        .style(ButtonStyle::Subtle)
-                        .icon(IconName::ArrowUpRight)
-                        .icon_size(IconSize::XSmall)
-                        .icon_color(Color::Muted)
-                        .on_click(move |_, _, cx| cx.open_url(OPENAI_CONSOLE_URL))
-                    )
-                )
                 .children(
-                    (2..INSTRUCTIONS.len()).map(|n|
+                    (0..INSTRUCTIONS.len()).map(|n|
                         Label::new(INSTRUCTIONS[n])).collect::<Vec<_>>())
                 .child(
                     h_flex()
@@ -519,12 +508,6 @@ impl Render for ConfigurationView {
                 .child(
                     Label::new(
                         format!("You can also assign the {OPENAI_API_KEY_VAR} environment variable and restart Zed."),
-                    )
-                    .size(LabelSize::Small),
-                )
-                .child(
-                    Label::new(
-                        "Note that having a subscription for another service like GitHub Copilot won't work.".to_string(),
                     )
                     .size(LabelSize::Small),
                 )


### PR DESCRIPTION
Removes all AI providers except for OpenAI and Ollama. OpenAI was left in because a lot of self-hostable LLM servers (such as llama.cpp) provide an OpenAI-compatible API. The built-in list of actual OpenAI models was removed as well, so only models configured by you will be listed.

There's no extra UI for configuring custom API URLs. In the meantime, an OpenAI-compatible API can be configured via the config file just like in regular Zed.
```json
{
  "language_models": {
    "openai": {
      "version": "1",
      "api_url": "http://localhost:9999/v1",
      "low_speed_timeout_in_seconds": 600,
      "available_models": [
        {
          "name": "model1",
          "max_tokens": 8192
        },
        {
          "name": "model2",
          "max_tokens": 16384
        },
      ]
    }
  }
```