### PR TITLE
Show only the close button on GNOME

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -312,6 +312,16 @@ pub enum Decorations {
     },
 }
 
+/// A type to describe the window style
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub enum WindowStyle {
+    /// GNOME Style
+    Gnome,
+    /// Any other desktop
+    #[default]
+    Other,
+}
+
 /// What window controls this platform supports
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct WindowControls {
@@ -437,6 +447,9 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     }
     fn window_controls(&self) -> WindowControls {
         WindowControls::default()
+    }
+    fn window_style(&self) -> WindowStyle {
+        WindowStyle::Other
     }
     fn set_client_inset(&self, _inset: Pixels) {}
     fn gpu_specs(&self) -> Option<GpuSpecs>;

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -21,11 +21,11 @@ use wayland_protocols::xdg::shell::client::xdg_surface;
 use wayland_protocols::xdg::shell::client::xdg_toplevel::{self};
 use wayland_protocols_plasma::blur::client::org_kde_kwin_blur;
 
-use crate::platform::{
+use crate::{platform::{
     blade::{BladeContext, BladeRenderer, BladeSurfaceConfig},
     linux::wayland::{display::WaylandDisplay, serial::SerialKind},
     PlatformAtlas, PlatformInputHandler, PlatformWindow,
-};
+}, WindowStyle};
 use crate::scene::Scene;
 use crate::{
     px, size, AnyWindowHandle, Bounds, Decorations, Globals, GpuSpecs, Modifiers, Output, Pixels,
@@ -804,6 +804,19 @@ impl PlatformWindow for WaylandWindow {
 
     fn appearance(&self) -> WindowAppearance {
         self.borrow().appearance
+    }
+
+    fn window_style(&self) -> crate::WindowStyle {
+        match std::env::var("XDG_CURRENT_DESKTOP") {
+            Ok(desktop) => {
+              if desktop == "GNOME" {
+                  WindowStyle::Gnome
+              } else {
+                  WindowStyle::Other
+              }
+            },
+            Err(_) => WindowStyle::Other,
+        }
     }
 
     fn display(&self) -> Option<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1,19 +1,5 @@
 use crate::{
-    point, prelude::*, px, size, transparent_black, Action, AnyDrag, AnyElement, AnyTooltip,
-    AnyView, App, AppContext, Arena, Asset, AsyncWindowContext, AvailableSpace, Background, Bounds,
-    BoxShadow, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
-    DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
-    FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
-    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
-    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
-    MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
-    PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, PromptLevel, Quad, Render,
-    RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge,
-    ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style, SubscriberSet,
-    Subscription, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement, TransformationMatrix,
-    Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance, WindowBounds,
-    WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem,
-    SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS,
+    point, prelude::*, px, size, transparent_black, Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, AppContext, Arena, Asset, AsyncWindowContext, AvailableSpace, Background, Bounds, BoxShadow, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style, SubscriberSet, Subscription, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement, TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowStyle, WindowTextSystem, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::{FxHashMap, FxHashSet};
@@ -1314,6 +1300,10 @@ impl Window {
     /// Returns the bounds of the current window in the global coordinate space, which could span across multiple displays.
     pub fn bounds(&self) -> Bounds<Pixels> {
         self.platform_window.bounds()
+    }
+
+    pub fn window_style(&self) -> WindowStyle {
+        self.platform_window.window_style()
     }
 
     /// Returns whether or not the window is currently fullscreen

--- a/crates/title_bar/src/platforms/platform_linux.rs
+++ b/crates/title_bar/src/platforms/platform_linux.rs
@@ -1,4 +1,4 @@
-use gpui::{prelude::*, Action, MouseButton};
+use gpui::{prelude::*, Action, MouseButton, WindowStyle};
 
 use ui::prelude::*;
 
@@ -7,12 +7,14 @@ use crate::window_controls::{WindowControl, WindowControlType};
 #[derive(IntoElement)]
 pub struct LinuxWindowControls {
     close_window_action: Box<dyn Action>,
+    window_style: WindowStyle,
 }
 
 impl LinuxWindowControls {
-    pub fn new(close_window_action: Box<dyn Action>) -> Self {
+    pub fn new(close_window_action: Box<dyn Action>, window_style: WindowStyle) -> Self {
         Self {
             close_window_action,
+            window_style
         }
     }
 }
@@ -24,20 +26,22 @@ impl RenderOnce for LinuxWindowControls {
             .px_3()
             .gap_3()
             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-            .child(WindowControl::new(
-                "minimize",
-                WindowControlType::Minimize,
-                cx,
-            ))
-            .child(WindowControl::new(
-                "maximize-or-restore",
-                if window.is_maximized() {
-                    WindowControlType::Restore
-                } else {
-                    WindowControlType::Maximize
-                },
-                cx,
-            ))
+            .when(self.window_style != WindowStyle::Gnome, |c| {
+                c.child(WindowControl::new(
+                    "minimize",
+                    WindowControlType::Minimize,
+                    cx,
+                ))
+                .child(WindowControl::new(
+                    "maximize-or-restore",
+                    if window.is_maximized() {
+                        WindowControlType::Restore
+                    } else {
+                        WindowControlType::Maximize
+                    },
+                    cx,
+                ))
+            })
             .child(WindowControl::new_close(
                 "close",
                 WindowControlType::Close,

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -217,7 +217,7 @@ impl Render for TitleBar {
                     PlatformStyle::Linux => {
                         if matches!(decorations, Decorations::Client { .. }) {
                             title_bar
-                                .child(platform_linux::LinuxWindowControls::new(close_action))
+                                .child(platform_linux::LinuxWindowControls::new(close_action, window.window_style()))
                                 .when(supported_controls.window_menu, |titlebar| {
                                     titlebar.on_mouse_down(
                                         gpui::MouseButton::Right,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/28dc1553-aa73-43c0-9d31-8097845c4857)
To be more consistent with GNOME style window decorations