### PR TITLE
Better feature activation mechanism using environment variable

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -15,6 +15,7 @@ use db::kvp::{GLOBAL_KEY_VALUE_STORE, KEY_VALUE_STORE};
 use editor::Editor;
 use env_logger::Builder;
 use extension::ExtensionHostProxy;
+use feature_flags::FeatureFlagAppExt;
 use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
@@ -37,7 +38,7 @@ use session::{AppSession, Session};
 use settings::{watch_config_file, Settings, SettingsStore};
 use simplelog::ConfigBuilder;
 use std::{
-    env,
+    env::{self, VarError},
     fs::OpenOptions,
     io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
@@ -558,6 +559,28 @@ fn main() {
 
         cx.set_menus(app_menus());
         initialize_workspace(app_state.clone(), prompt_builder, cx);
+
+        let mut feature_flags = env::var("ZED_ENABLE_EXPERIMENTAL_FEATURES")
+            .and_then(|s| {
+                if s.is_empty() {
+                    Err(VarError::NotPresent)
+                } else {
+                    Ok(s)
+                }
+            })
+            .map_or_else(
+                |e| {
+                    if e == VarError::NotPresent {
+                        Vec::new()
+                    } else {
+                        panic!("Invalid ZED_ENABLE_EXPERIMENTAL_FEATURES: {:?}", e)
+                    }
+                },
+                |s| s.split(',').map(|s| s.to_string()).collect(),
+            );
+        feature_flags.sort();
+        feature_flags.dedup();
+        cx.update_flags(false, feature_flags);
 
         cx.activate(true);
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -561,6 +561,17 @@ fn main() {
         initialize_workspace(app_state.clone(), prompt_builder, cx);
 
         let mut feature_flags = env::var("ZED_ENABLE_EXPERIMENTAL_FEATURES")
+            .map_or_else(
+                |e| {
+                    if e == VarError::NotPresent {
+                        // List of features enabled if variable is not present.
+                        Ok("git-ui".to_string())
+                    } else {
+                        Err(e)
+                    }
+                },
+                |s| Ok(s),
+            )
             .and_then(|s| {
                 if s.is_empty() {
                     Err(VarError::NotPresent)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -15,7 +15,6 @@ use db::kvp::{GLOBAL_KEY_VALUE_STORE, KEY_VALUE_STORE};
 use editor::Editor;
 use env_logger::Builder;
 use extension::ExtensionHostProxy;
-use feature_flags::FeatureFlagAppExt;
 use fs::{Fs, RealFs};
 use futures::{future, StreamExt};
 use git::GitHostingProviderRegistry;
@@ -559,8 +558,6 @@ fn main() {
 
         cx.set_menus(app_menus());
         initialize_workspace(app_state.clone(), prompt_builder, cx);
-
-        cx.update_flags(false, vec!["git-ui".to_string()]);
 
         cx.activate(true);
 


### PR DESCRIPTION
This adds new environment variable `ZED_ENABLE_EXPERIMENTAL_FEATURES` that accepts comma-separated list of features:

```bash
# Enable only `feat1` and `feat2`:
ZED_ENABLE_EXPERIMENTAL_FEATURES=feat1,feat2 zed

# Run with default features (only `git-ui` currently):
zed

# Run with all experimental features disabled (`git-ui` is disabled too):
ZED_ENABLE_EXPERIMENTAL_FEATURES= zed
```