### PR TITLE
Don't complain about missing language servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8834,6 +8834,7 @@ dependencies = [
  "util",
  "watch",
  "workspace-hack",
+ "zedless",
  "zlog",
 ]
 
@@ -8855,6 +8856,7 @@ dependencies = [
  "serde_json",
  "util",
  "workspace-hack",
+ "zedless",
 ]
 
 [[package]]
@@ -12206,6 +12208,7 @@ dependencies = [
  "which 6.0.3",
  "workspace-hack",
  "worktree",
+ "zedless",
  "zlog",
 ]
 
@@ -20051,6 +20054,7 @@ dependencies = [
 name = "zedless"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "workspace-hack",
 ]
 

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -69,6 +69,7 @@ unicase = "2.6"
 util.workspace = true
 watch.workspace = true
 workspace-hack.workspace = true
+zedless.workspace = true
 diffy = "0.4.2"
 
 [dev-dependencies]

--- a/crates/language_extension/Cargo.toml
+++ b/crates/language_extension/Cargo.toml
@@ -26,3 +26,4 @@ serde.workspace = true
 serde_json.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
+zedless.workspace = true

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -21,6 +21,7 @@ use lsp::{
 use serde::Serialize;
 use serde_json::Value;
 use util::{ResultExt, fs::make_file_executable, maybe};
+use zedless::SilentError;
 
 use crate::{LanguageServerRegistryProxy, LspAccess};
 
@@ -161,7 +162,7 @@ impl LspAdapter for ExtensionLspAdapter {
         _: Arc<dyn LanguageToolchainStore>,
         _: LanguageServerBinaryOptions,
         _: &'a mut AsyncApp,
-    ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary>>>> {
+    ) -> Pin<Box<dyn 'a + Future<Output = Result<LanguageServerBinary, SilentError>>>> {
         async move {
             let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;
             let command = self

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -88,6 +88,7 @@ which.workspace = true
 worktree.workspace = true
 zlog.workspace = true
 workspace-hack.workspace = true
+zedless.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/zedless/Cargo.toml
+++ b/crates/zedless/Cargo.toml
@@ -12,4 +12,5 @@ workspace = true
 path = "src/zedless.rs"
 
 [dependencies]
+anyhow.workspace = true
 workspace-hack.workspace = true

--- a/crates/zedless/src/zedless.rs
+++ b/crates/zedless/src/zedless.rs
@@ -1,1 +1,13 @@
+/// Provides a way to handle errors that can be ignored.
+pub enum SilentError {
+    /// The operation failed, but the error should be ignored.
+    Silent,
+    /// The operation failed, and the error should be handled normally.
+    Error { error: anyhow::Error },
+}
 
+impl From<anyhow::Error> for SilentError {
+    fn from(err: anyhow::Error) -> Self {
+        SilentError::Error { error: err }
+    }
+}


### PR DESCRIPTION
Depends on #28 

Silences errors about missing LSP binaries, displaying the LSP server as `Stopped` in the UI. This way, you can have all your LSP server configs always ready to go and the editor won't nag you when your devShell doesn't provide all of them.