### PR TITLE
Use `lib/zedless` for non-libexec distros

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -424,10 +424,10 @@ mod linux {
                 let cli = env::current_exe()?;
                 let dir = cli.parent().context("no parent path for cli")?;
 
-                // libexec is the standard, lib/zed is for Arch (and other non-libexec distros),
+                // libexec is the standard, lib/zedless is for Arch (and other non-libexec distros),
                 // ./zed is for the target directory in development builds.
                 let possible_locations =
-                    ["../libexec/zedless-editor", "../lib/zed/zedless-editor", "./zed"];
+                    ["../libexec/zedless-editor", "../lib/zedless/zedless-editor", "./zed"];
                 possible_locations
                     .iter()
                     .find_map(|p| dir.join(p).canonicalize().ok().filter(|path| path != &cli))


### PR DESCRIPTION
Non-libexec distros like Arch Linux or (pending) Chimera Linux should be installing the editor binary to `/usr/lib/zedless/zedless-editor`, not `/usr/lib/zed/zedless-editor`.