### PR TITLE
Replace Zed name in menus

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -256,13 +256,7 @@ pub fn app_menus() -> Vec<Menu> {
                     super::OpenBrowser {
                     	url: "https://github.com/zedless-editor/zedless".into(),
                     },
-                ),
-                MenuItem::action(
-                    "Join the Team",
-                    super::OpenBrowser {
-                        url: "https://zed.dev/jobs".into(),
-                    },
-                ),
+                )
             ],
         },
     ]


### PR DESCRIPTION
* `Zed` menu itself
* `About Zed...`
* `Hide Zed`
* `Quit Zed`
* `Zed Twitter`
  * Replaced with `Zedless Repository` linking to this repo

Bonus: Removed `Join the Team` menu item 