### PR TITLE
Add migration and compatibility for Prettier

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -807,7 +807,7 @@ impl JsonSchema for SelectedFormatter {
                 },
                 {
                     "type": "string",
-                    "enum": ["auto", "language_server"]
+                    "enum": ["auto", "prettier", "language_server"]
                 },
                 formatter_schema
             ]
@@ -845,6 +845,8 @@ impl<'de> Deserialize<'de> for SelectedFormatter {
                 E: serde::de::Error,
             {
                 if v == "auto" {
+                    Ok(Self::Value::Auto)
+                } else if v == "prettier" { // fallback for deprecated setting
                     Ok(Self::Value::Auto)
                 } else if v == "language_server" {
                     Ok(Self::Value::List(FormatterList::Single(

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -99,3 +99,9 @@ pub(crate) mod m_2025_07_08 {
 
     pub(crate) use settings::SETTINGS_PATTERNS;
 }
+
+pub(crate) mod m_2025_11_29_zedless {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2025_11_29_zedless/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_11_29_zedless/settings.rs
@@ -1,0 +1,35 @@
+use std::ops::Range;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::SETTINGS_LANGUAGES_PATTERN;
+
+pub const SETTINGS_PATTERNS: MigrationPatterns =
+    &[(SETTINGS_LANGUAGES_PATTERN, migrate_prettier_to_auto)];
+
+fn migrate_prettier_to_auto(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let name_ix = query.capture_index_for_name("setting_name")?;
+    let name_range = mat.nodes_for_capture_index(name_ix).next()?.byte_range();
+    let name = contents.get(name_range)?;
+
+    if name != "formatter" {
+        return None;
+    }
+
+    let value_ix = query.capture_index_for_name("value")?;
+    let value_node = mat.nodes_for_capture_index(value_ix).next()?;
+    let value_range = value_node.byte_range();
+    let value = contents.get(value_range.clone())?;
+
+    match value {
+        "\"prettier\"" => {
+            let replacement = "\"auto\"".to_string();
+            Some((value_range, replacement))
+        }
+        _ => None,
+    }
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -164,6 +164,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
             migrations::m_2025_07_08::SETTINGS_PATTERNS,
             &SETTINGS_QUERY_2025_07_08,
         ),
+        (
+            migrations::m_2025_11_29_zedless::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2025_11_29_ZEDLESS,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -277,6 +281,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_07_08,
     migrations::m_2025_07_08::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2025_11_29_ZEDLESS,
+    migrations::m_2025_11_29_zedless::SETTINGS_PATTERNS
 );
 
 // custom query


### PR DESCRIPTION
Fixes #54 

This uses the preexisting migration system. It seems that such migrations don't get applied to project settings, only the user settings (i.e. `~/.config/zed/settings.json`).