### PR TITLE
Show a message when LSP binary is not available

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -466,6 +466,7 @@ impl ActivityIndicator {
                     failed.push(status.name.clone());
                 }
                 LanguageServerStatusUpdate::Binary(BinaryStatus::None) => {}
+                LanguageServerStatusUpdate::Binary(BinaryStatus::NotAvailable) => {}
                 LanguageServerStatusUpdate::Health(health, server_status) => match server_status {
                     Some(server_status) => {
                         health_messages.push((status.name.clone(), *health, server_status.clone()));

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -161,6 +161,7 @@ pub enum BinaryStatus {
     Stopping,
     Stopped,
     Failed { error: String },
+    NotAvailable,
 }
 
 #[derive(Clone)]

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -226,6 +226,7 @@ impl LanguageServerState {
                     BinaryStatus::Stopping => Some(Color::Disabled),
                     BinaryStatus::Stopped => Some(Color::Disabled),
                     BinaryStatus::Failed { .. } => Some(Color::Error),
+                    BinaryStatus::NotAvailable => Some(Color::Info),
                 })
                 .or_else(|| {
                     Some(match server_info.health? {
@@ -774,6 +775,7 @@ impl LspTool {
                     }
                     BinaryStatus::Stopped => {}
                     BinaryStatus::Failed { .. } => {}
+                    BinaryStatus::NotAvailable => {}
                 }
 
                 match server_names_to_worktrees.get(server_name) {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -367,7 +367,7 @@ impl LocalLspStore {
                     }
 
                     Err(SilentError::Silent) => {
-                        delegate.update_status(adapter.name(), BinaryStatus::Stopped);
+                        delegate.update_status(adapter.name(), BinaryStatus::NotAvailable);
                         None
                     }
 
@@ -11332,6 +11332,10 @@ fn subscribe_to_binary_statuses(
                         BinaryStatus::Failed { error } => {
                             message = Some(error);
                             proto::ServerBinaryStatus::Failed
+                        }
+                        BinaryStatus::NotAvailable => {
+                            message = Some("The binary for this language server is not available.".to_string());
+                            proto::ServerBinaryStatus::Stopped
                         }
                     };
                     cx.emit(LspStoreEvent::LanguageServerUpdate {


### PR DESCRIPTION
Fixes #56 

Sort of a first PoC. This creates a message indicator in the LSP menu. Clicking it opens a buffer with a message such as:

```
Language server json-language-server:

The binary for this language server is not available.
```

What do you think? @ItsHarper 

Bug: The `Info` color is currently ignored because the `LanguageServerUpdate` immediately transitions the given LSP server into the `Stopped` state immediately.