### PR TITLE
nix: fix cargo-about

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -69,6 +69,10 @@ rustPlatform.buildRustPackage {
 
   postPatch = ''
     echo stable > crates/zed/RELEASE_CHANNEL
+    # The generate-licenses script wants a specific version of cargo-about eventhough
+    # newer versions work just as well.
+    substituteInPlace script/generate-licenses \
+      --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
   '';
 
   cargoDeps = rustPlatform.importCargoLock {


### PR DESCRIPTION
Build currently fails on nixos 25.11/unstable as cargo-about has been updated to 0.8.x. This pulls in https://github.com/NixOS/nixpkgs/pull/440888 to fix it.